### PR TITLE
Fix int and float inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,14 +49,14 @@ const inst = new WebAssembly.Instance(mod, {
       const val = scratch.get(id);
       const addr = inst.exports.malloc(4);
       const arr = new Uint32Array(inst.exports.memory.buffer);
-      arr.set(val, addr / 4);
+      arr.set([val], addr / 4);
       return addr;
     },
     getDouble: (id) => {
       const val = scratch.get(id);
       const addr = inst.exports.malloc(8);
       const arr = new Float64Array(inst.exports.memory.buffer);
-      arr.set(val, addr / 8);
+      arr.set([val], addr / 8);
       return addr;
     },
     getStr: (id) => {

--- a/test/index.js
+++ b/test/index.js
@@ -114,7 +114,7 @@ const benchmarkGen = (methodName, genArgs, useTryCatch = false, extraName = '') 
   console.log('')
   console.log(`${methodName}${extraName} Benchmark:`)
   console.log('H3-js time in ns:   ', h3jsTime[0] * 1e9 + h3jsTime[1])
-  console.log('H3-node time in ns: ', h3wasmTime[0] * 1e9 + h3wasmTime[1])
+  console.log('H3-wasm time in ns: ', h3wasmTime[0] * 1e9 + h3wasmTime[1])
   test.done()
 }
 


### PR DESCRIPTION
While digging into the test suite output, noticed that the index was wrong because the arguments were all zeroes. This fixes the input loading for these two types
