### PR TITLE
Fix latLngToCell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ h3:
 	cd h3 && git checkout v4.1.0 && cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fPIC
 
 h3.wasm: h3.zig h3
-	zig build-lib h3.zig -target wasm32-freestanding-musl -dynamic -O ReleaseSmall -rdynamic -lc -I./h3/src/h3lib/include ./h3/src/h3lib/lib/*.c
+	zig build-lib h3.zig -target wasm32-freestanding-musl -dynamic -O ReleaseSmall -rdynamic -I./h3/src/h3lib/include ./h3/src/h3lib/lib/*.c -lc -lm --verbose-cc --verbose-link --verbose-cimport
 
 hello: h3.wasm
 	node hello.js

--- a/index.js
+++ b/index.js
@@ -47,14 +47,14 @@ const inst = new WebAssembly.Instance(mod, {
     },
     getInt32: (id) => {
       const val = scratch.get(id);
-      const addr = inst.exports.malloc(4);
+      const addr = inst.exports.alloc(4);
       const arr = new Uint32Array(inst.exports.memory.buffer);
       arr.set([val], addr / 4);
       return addr;
     },
     getDouble: (id) => {
       const val = scratch.get(id);
-      const addr = inst.exports.malloc(8);
+      const addr = inst.exports.alloc(8);
       const arr = new Float64Array(inst.exports.memory.buffer);
       arr.set([val], addr / 8);
       return addr;
@@ -62,7 +62,7 @@ const inst = new WebAssembly.Instance(mod, {
     getStr: (id) => {
       const val = scratch.get(id);
       const len = val.length + 1;
-      const addr = inst.exports.malloc(len);
+      const addr = inst.exports.alloc(len);
       const arr = new Uint8Array(inst.exports.memory.buffer);
       arr.set(val.split('').map(c => c.charCodeAt(0)), addr);
       return addr;


### PR DESCRIPTION
Resolves #3

The root issue the whole time was the C function taking in radians but the bindings all taking in degrees for this function. Why did we decide to do that way back then?

This PR also has some minor cleanup work and renaming my `malloc` to just `alloc` to be clear it's not the actual C `malloc` function (though it should behave the same I don't exactly care if it does or not, so don't want to imply that it has to).
